### PR TITLE
fix: fix relative path used in links

### DIFF
--- a/mkdocs/docs/architecture.md
+++ b/mkdocs/docs/architecture.md
@@ -157,4 +157,4 @@ Voici globalement les dossiers utilisés pour créer l'architecture d'Eirbware
 À noter, le dossier de configuration du `nginx` principal est `/etc/nginx`,
 celui de `wireguard` est `/etc/wireguard` et celui de `sshd` est `/etc/sshd`.
 
-Pour plus de détails, référez-vous à la page de [gestion du VPS](gestion_vps.md).
+Pour plus de détails, référez-vous à la page de [gestion du VPS](./gestion_vps/intro.md).

--- a/mkdocs/docs/gestion_vps/firewall.md
+++ b/mkdocs/docs/gestion_vps/firewall.md
@@ -20,7 +20,7 @@ conseillons [cet article](https://www.redhat.com/en/blog/beginners-guide-firewal
 
 ### Utilisation de `crowdsec`
 
-Comme décrit dans [l'architecture globale](architecture.md), `crowdsec` a
+Comme décrit dans [l'architecture globale](../architecture.md), `crowdsec` a
 besoin **d'accéder en lecture aux logs** qu'il analyse.
 
 Pour simplifier sa mise en place, `crowdsec` est lancé dans un docker rootful,

--- a/mkdocs/docs/gestion_vps/intro.md
+++ b/mkdocs/docs/gestion_vps/intro.md
@@ -5,4 +5,4 @@ beaucoup).
 
 Cette page se concentre sur les détails techniques associés à chaque aspect du
 VPS, il est **vivement conseillé** de bien avoir en tête
-[l'architecture globale du serveur.](architecture.md)
+[l'architecture globale du serveur.](../architecture.md)

--- a/mkdocs/docs/gestion_vps/sudo.md
+++ b/mkdocs/docs/gestion_vps/sudo.md
@@ -1,7 +1,7 @@
 # Utilisation de `sudo`
 
 Une utilisation incorrecte de `sudo` mène généralement à une utilisation non
-prévue du serveur (cf [historique de l'architecture](architecture.md#historique-de-larchitecture)).
+prévue du serveur (cf [historique de l'architecture](../architecture.md#historique-de-larchitecture)).
 
 ## Whitelist des programmes disponibles
 


### PR DESCRIPTION
Relative paths were wrong, leading to errors in link generation

Ex:

in https://docs.eirb.fr/gestion_vps/intro/, the link sends to https://docs.eirb.fr/gestion_vps/intro/architecture.md instead of https://docs.eirb.fr/architecture/