### PR TITLE
proposal: remove docker-compose and use docker cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,29 @@
+MKDOCS_IMAGE := squidfunk/mkdocs-material:latest
 
-.PHONY: all
-all:
+MKDOCS := docker run --rm -u $(shell id -u) -v ./mkdocs:/docs $(MKDOCS_IMAGE)
+MKDOCS_DEV := docker run --rm -u $(shell id -u) -v ./mkdocs:/docs -p 8000:8000 $(MKDOCS_IMAGE)
 
-.PHONY: dev
+PHONY += all
+all: build
+
+PHONY += dev
 dev:
-	docker compose up -d
+	$(MKDOCS_DEV)
 
-.PHONY: build
+PHONY += build
 build:
-	docker compose up -d
-	docker exec mkdocs mkdocs build
+	$(MKDOCS) build
 
-.PHONY: start
+PHONY += start
 start:
 	python -m http.server 8080 -d mkdocs/site
 
-
-.PHONY:clean
+PHONY += clean
 clean:
-	sudo ${RM} -r mkdocs/site
-	docker compose down
+	${RM} -r mkdocs/site
+
+PHONY += mrproper
+mrproper: clean
+	docker rmi $(MKDOCS_IMAGE)
+
+.PHONY: $(PHONY)

--- a/README.md
+++ b/README.md
@@ -13,9 +13,16 @@ suivant : https://squidfunk.github.io/mkdocs-material/getting-started/
 
 ## Développement
 
-Ce dépôt propose un fichier `docker-compose.yml`, il sert **uniquement au
-développement et à la compilation**. Le but étant de ne pas avoir à installer
-`mkdocs` pour pouvoir contribuer à ce dépôt.
+Ce dépôt utilise [docker](https://docs.docker.com/engine/install/) afin de
+compiler et de créer un environnement de développement.
+
+Le but étant de ne pas avoir à installer `mkdocs` pour pouvoir contribuer à ce
+dépôt. De plus, il suffit d'exécuter la commande suivante pour supprimer les
+fichiers compilés et les images docker téléchargées :
+
+```sh
+make mrproper
+```
 
 ### Démarrer le serveur de développement
 
@@ -23,7 +30,7 @@ développement et à la compilation**. Le but étant de ne pas avoir à installe
 faisant :
 
 ```sh
-docker compose up -d
+make dev
 ```
 
 ### Modifications du site

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,0 @@
-# Important note : this is dev container, for prod run `make build`
-services:
-  mkdocs:
-    image: squidfunk/mkdocs-material:latest
-    container_name: mkdocs
-    ports:
-      - 8000:8000
-    volumes:
-      - ./mkdocs:/docs


### PR DESCRIPTION
1. fix `.PHONY` targets, do it the right way using a `PHONY` variable

2. add `mrproper` target to clean up all dependencies and build artifacts

3. Remove the docker-compose.yml file because it seems unnecessary

using docker run to start mkdocs is actually fine, and may prevent forgetting to remove auto restarting containers from docker-compose

extra: update README.md to this change, and add `-u $(shell id -u)` in docker args, this way the user in the container will be the current user and will prevent messing around the owner of built files, making `sudo` in the `clean` target unnecessary