### PR TITLE
Document manual gitlab pipeline

### DIFF
--- a/mkdocs/docs/gestion_vps/users.md
+++ b/mkdocs/docs/gestion_vps/users.md
@@ -32,22 +32,22 @@ sudo new_admin <cas_login>  # Créé l'utilisateur adm-<cas_login>
 
 #### Création de l'accès `SSH`
 
-Comme dit précédemment, l'accès par `SSH` se fait par clef et certificat, le
-nouvel administrateur devra créer une paire de clefs spécifiquement pour
+Comme dit précédemment, l'accès par `SSH` se fait par clé et certificat, le
+nouvel administrateur devra créer une paire de clés spécifiquement pour
 Eirbware en utilisant la commande suivante :
 
-```title="Création d'une paire de clefs `SSH` par le futur administrateur"
+```title="Création d'une paire de clés `SSH` par le futur administrateur"
 ssh-keygen -t ed25519
 ```
 
-Il devra ensuite transmettre la clef publique à l'utilisateur qui créé l'accès
+Il devra ensuite transmettre la clé publique à l'utilisateur qui créé l'accès
 `SSH` afin de créer le certificat.
 
-!!!info "Stockage des clefs publiques"
+!!!info "Stockage des clés publiques"
 
-    Les clefs publiques des utilisateurs sont stockées dans le dossier
+    Les clés publiques des utilisateurs sont stockées dans le dossier
     `/int/int-ssh/public_keys` avec le nom `id_<cas_login>.pub`, cela permet de
-    créer un nouveau certificat sans avoir à retransmettre la clef publique.
+    créer un nouveau certificat sans avoir à retransmettre la clé publique.
 
     Il peut être utile de créer un nouveau certificat si un admin veut utiliser
     un accès `SFTP` ou si un respo web s'occuper de plusieurs sites
@@ -61,7 +61,7 @@ sudo cert_new -k /int/int-ssh/public_keys/id_<cas_login>.pub adm-<cas_login>
 
 !!!info "Passphrase du certificat d'Eirbware"
 
-    Afin de signer la clef publique, la passphrase du certificat d'Eirbware est
+    Afin de signer la clé publique, la passphrase du certificat d'Eirbware est
     nécessaire, vous la trouverez sur le [Vaultwarden d'Eirbware](https://vault.eirb.fr).
 
 #### Création de l'accès wireguard
@@ -78,21 +78,21 @@ En vrai c'est pas dispo atm
 Donner les accès au respo web d'un asso à son site se fait en 2 étapes:
 
 * Créer un accès `SSH`
-* Créer un accès wireguard 
+* Créer un accès wireguard
 
-#### Création de l'accès ssh utilisateur 
+#### Création de l'accès ssh utilisateur
 
-Similairement à la création d'un administrateur, le respo web devra créer une paire de clefs spécifiquement pour Eirbware, de la manière suivante:
+Similairement à la création d'un administrateur, le respo web devra créer une paire de clés spécifiquement pour Eirbware, de la manière suivante:
 
-```title="Création d'une paire de clefs `SSH` par le futur administrateur"
+```title="Création d'une paire de clés `SSH` par le futur administrateur"
 ssh-keygen -t ed25519
 ```
 
 Il devra ensuite transmettre sa clé publique à un administrateur d'Eirbware.
 
-!!!info "Stockage des clefs publiques"
+!!!info "Stockage des clés publiques"
 
-    Comme dit précédemment, les clefs publiques des utilisateurs sont stockées dans le dossier
+    Comme dit précédemment, les clés publiques des utilisateurs sont stockées dans le dossier
     `/int/int-ssh/public_keys` avec le nom `id_<cas_login>.pub`.
 
 Ensuite, celui-ci créera un certificat avec la commande suivante:
@@ -103,7 +103,7 @@ sudo cert_new -k /int/int-ssh/public_keys/id_<cas_login>.pub www-<nom_site> <cas
 
 !!!info "Passphrase du certificat d'Eirbware"
 
-    Afin de signer la clef publique, la passphrase du certificat d'Eirbware est
+    Afin de signer la clé publique, la passphrase du certificat d'Eirbware est
     nécessaire, vous la trouverez sur le [Vaultwarden d'Eirbware](https://vault.eirb.fr).
 
 #### Création de l'accès wireguard
@@ -121,6 +121,6 @@ sudo cert_revoke <certificate_ID>
 ```
 
 !!!info "Réactiver un certificat"
-    
-    Si un certificat a été révoqué par erreur, il est possible d'annuler cette action avec l'option `-r` de la commande 
+
+    Si un certificat a été révoqué par erreur, il est possible d'annuler cette action avec l'option `-r` de la commande
     `cert_revoke`

--- a/mkdocs/docs/passation.md
+++ b/mkdocs/docs/passation.md
@@ -8,7 +8,7 @@ d'informations.
 ## Accès au local
 
 Généralement, tous les membres d'Eirbware ont accès par badge au local, le
-nouveau président d'Eirbware se voit remettre par le président sortant la clef
+nouveau président d'Eirbware se voit remettre par le président sortant la clé
 du local.
 
 Pour ce qui est de la procédure d'ajout d'accès au local, elle est partagée
@@ -37,7 +37,7 @@ puis il a la responsabilité de le partager avec **tous les membres d'Eirbware**
 ## Gestionnaire de mots de passes : Vaultwarden
 
 On utilise [Vaultwarden](https://github.com/dani-garcia/vaultwarden), une
-alternative open-source à Bitwarden, qui est compatible avec 
+alternative open-source à Bitwarden, qui est compatible avec
 [les clients](https://github.com/bitwarden/clients) développés par Bitwarden,
 qui sont [(globalement) open-source](https://community.bitwarden.com/t/concerns-over-bitwarden-moving-away-from-open-source-what-does-our-future-hold/74800)
 
@@ -180,23 +180,23 @@ trouvable sur [le vaultwarden](https://vault.eirb.fr).
 Il suffit ensuite d'exécuter la commande suivante :
 
 ```sh
-sudo cert_new -k <chemin vers clef publique> adm-<admin name>
+sudo cert_new -k <chemin vers clé publique> adm-<admin name>
 ```
 
 Par exemple, la commande suivante va créer un certificat `/tmp/id-cert.pub` pour
-la clef publique donnée `/tmp/id.pub` pour l'utilisateur `adm-ndacremont`.
+la clé publique donnée `/tmp/id.pub` pour l'utilisateur `adm-ndacremont`.
 
 ```sh
 sudo cert_new -k /tmp/id.pub adm-ndacremont
 ```
 
-Le mieux est de demander la clef `SSH` publique des membres d'Eirbware
+Le mieux est de demander la clé `SSH` publique des membres d'Eirbware
 
 !!!info "Accès à la _passphrase_ du certificat"
 
     Avant, seul le président d'Eirbware avait accès à la _passphrase_ du
     certificat.
-    
+
     Sachant que les accès à la mise à jour des sites se fait maintenant en
     `SFTP`, il a été jugé plus simple de permettre à tous les membres ayant
     accès au serveur de créer de nouveaux accès `SFTP` quitte à ce qu'ils

--- a/mkdocs/docs/respo_web/acces_site.md
+++ b/mkdocs/docs/respo_web/acces_site.md
@@ -1,36 +1,36 @@
 # Comment demander un accès pour mettre à jour un site
 
 La modification d'un site web se fait par `SFTP`, qui est un protocole construit
-à partir de `SSH`. Et l'accès se fait exclusivement par clef.
+à partir de `SSH`. Et l'accès se fait exclusivement par clé.
 
-Les instructions suivantes permettent de savoir comment créer une clef `SSH` et
+Les instructions suivantes permettent de savoir comment créer une clé `SSH` et
 la configuration pour mettre à jour un site.
 
-## Création d'une clef `SSH`
+## Création d'une clé `SSH`
 
-Il est conseillé de créer une clef `SSH` spécifiquement pour Eirbware, vous
+Il est conseillé de créer une clé `SSH` spécifiquement pour Eirbware, vous
 pouvez en créer une de la façon suivante :
 
-```title="Création d'un clef `SSH`"
+```title="Création d'un clé `SSH`"
 ssh-keygen -t ed25519
 ```
 
-Après l'exécution de cette commande, deux fichiers ont été créés : une clef
-privée `filename` et une clef publique `filename.pub`.
+Après l'exécution de cette commande, deux fichiers ont été créés : une clé
+privée `filename` et une clé publique `filename.pub`.
 
-!!!warning "Sécurité des clefs"
+!!!warning "Sécurité des clés"
 
-    Vous **ne devez pas, sous aucun prétexte, partager la clef privée**, cela
+    Vous **ne devez pas, sous aucun prétexte, partager la clé privée**, cela
     permettrait à un tiers d'usurper votre identité.
 
-    Cependant, vous pouvez partager la clef publique, elle ne sert à rien sans la
-    clef privée.
+    Cependant, vous pouvez partager la clé publique, elle ne sert à rien sans la
+    clé privée.
 
 ## Certificat `SSH`
 
 Eirbware utilise des [certificats `SSH`](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/deployment_guide/sec-using_openssh_certificate_authentication)
-afin d'autoriser la connexion d'une paire de clefs `SSH` au serveur. Pour en
-créer un, Eirbware a besoin de la clef publique que vous venez de générer pour
+afin d'autoriser la connexion d'une paire de clés `SSH` au serveur. Pour en
+créer un, Eirbware a besoin de la clé publique que vous venez de générer pour
 créer un certificat.
 
 Vous devez donc à partir de là contacter un membre d'Eirbware comme proposé en
@@ -52,7 +52,7 @@ Host eirb_pix
     port 30
     Hostname eirb.fr
     User www-pix
-    IdentityFile    ~/.ssh/<Votre clef SSH>
+    IdentityFile    ~/.ssh/<Votre clé SSH>
     CertificateFile ~/.ssh/<Votre certificat SSH>
 ```
 

--- a/mkdocs/docs/respo_web/ci_eirbware.md
+++ b/mkdocs/docs/respo_web/ci_eirbware.md
@@ -1,4 +1,4 @@
-# La CI/CD à Eirbware
+# CI/CD Eirbware
 
 Afin de faciliter la maintenance ainsi que le déploiement des services proposés par Eirbware ainsi que les sites internets des clubs/assos, nous avons mis en place des méthodes de déploiement automatique.
 
@@ -10,12 +10,12 @@ Ainsi, pour utiliser une de nos actions, on peut définir un job ayant cette for
 ```yaml
   build-and-push:
     permissions:
-      id-token: write 
+      id-token: write
     uses: Eirbware/.github/.github/workflows/build-and-publish.yml@master
     with:
       file: "./Dockerfile"
       image_name: ${{ github.repository }}
-    secrets: 
+    secrets:
       registry_username: ${{ secrets.registry_username }}
       registry_api_key: ${{ secrets.registry_api_key }}
 ```
@@ -25,18 +25,18 @@ Il y 2 types d'entrées à ces jobs:
 - Les paramètres, sous l'option `with`
 - Les secrets, sous l'option `secrets`, qui contient les données sensibles dont le job a besoin
 
-!!!warning 
+!!!warning
     Il est vivement conseillé d'utiliser les jobs de cette façon pour déployer sur notre serveur, ainsi si un changement survient il n'y aura pas de modification à faire sur les dépôts utilsant l'action.
 
-!!!info 
+!!!info
     Pour définir les secrets et les utiliser comme vu au dessus, il faut aller dans les options du dépôt, dans secrets and variables et dans actions
 
-!!!info 
+!!!info
     Pour les services étant sous l'organisation github d'Eirbware, on peut aussi utiliser `secrets: inherit`
 
 ## Les services statiques
 
-Pour les sites statiques, nous mettons à disposition un job permettant de copier les fichiers du site vers le serveur. 
+Pour les sites statiques, nous mettons à disposition un job permettant de copier les fichiers du site vers le serveur.
 Ce job a cette forme:
 ```yaml
 deploy-static:
@@ -44,7 +44,7 @@ deploy-static:
     with:
         remote_user: "www-eirb"
         directory_to_copy: "./dist"
-    secrets: 
+    secrets:
         ssh_secret_key: ${{ secrets.ssh_private_key }}
         ssh_public_key: ${{ secrets.ssh_public_key }}
         ssh_cert: ${{ secrets.ssh_cert }}
@@ -57,7 +57,7 @@ Les paramètres de ce job sont:
 * `remote_user` (obligatoire): Le nom de l'utilisateur sur nos serveurs (usuellement `www-<nom-du-service>`)
 * `directory_to_copy` (obligatoire): Le dossier source, contenant les fichiers du site
 * `artifact_name` (ignoré par défaut): Nom de l'artéfact à utiliser (voir [ici](https://docs.github.com/en/actions/concepts/workflows-and-actions/workflow-artifacts) pour la documentation sur le sujet)
-* `artifact_path` (ignoré par défaut, obligatoire si `artifact_name` est non nul): Chemin vers lequel l'artéfact doit être copié 
+* `artifact_path` (ignoré par défaut, obligatoire si `artifact_name` est non nul): Chemin vers lequel l'artéfact doit être copié
 
 ## Les services conteneurisées
 
@@ -69,17 +69,17 @@ Le job permettant de faire cela a cette forme:
 ```yaml
   build-and-push:
     permissions:
-      id-token: write 
+      id-token: write
     uses: Eirbware/.github/.github/workflows/build-and-publish.yml@master
     with:
       file: "./Dockerfile"
       image_name: ${{ github.repository }}
-    secrets: 
+    secrets:
       registry_username: ${{ secrets.registry_username }}
       registry_api_key: ${{ secrets.registry_api_key }}
 ```
 
-!!!warning 
+!!!warning
     Il ne faut pas omettre l'option `permissions: id-token: write`, sans quoi l'action ne fonctionnera pas.
 
 Il va compiler le docker puis publier l'image sur [registry.eirb.fr](https://registry.eirb.fr), d'où il pourra être pull par sur le serveur.
@@ -96,13 +96,13 @@ Ensuite, ce job a besoin de 2 secrets: `registry_username` et `registry_api_key`
 
 Si vous n'avez pas le `registry_username`, contactez-nous pour créer un compte, ce secret sera l'email associé au compte (plus de détails [ici](../gestion_vps/registry.md) pour le côté administrateur).
 
-Une fois que cela est fait, connectez vous avec ce compte sur [le registry](https://registry.eirb.fr), puis en haut à gauche accédez à l'écran `API keys`. 
+Une fois que cela est fait, connectez vous avec ce compte sur [le registry](https://registry.eirb.fr), puis en haut à gauche accédez à l'écran `API keys`.
 A partir de là, vous pouvez créer une clé api, que vous devrez mettre dans le secret `registry_api_key`.
 
-!!!info 
+!!!info
     Nous vous conseillons de créer une clé api par service, afin de pouvoir éventuellement supprimer/renouveler une clé d'un service sans affecter les autres.
 
-!!!warning 
+!!!warning
     Lors de la création de la clé, une date d'expiration doit être fixée, n'oubliez pas de renouveler la clé si la date est proche !
 
 ### Déploiement
@@ -167,13 +167,13 @@ services:
 Afin de gérer les différents environments, nous utilisons [portainer](https://www.portainer.io/), donc pour pouvoir déployer un service conteneurisé sur notre infrastructure, il faut d'abord que nous vous donnions accès à un environment.
 
 Ensuite, dans l'environment, il faut aller dans Stacks->Add stacks.
-Une fois dans cet écran, donnez un nom à votre stack (nous utilisons www-\<service\> par exemple) et sélétionnez l'option `Repository`. 
+Une fois dans cet écran, donnez un nom à votre stack (nous utilisons www-\<service\> par exemple) et sélétionnez l'option `Repository`.
 Après cela, remplissez les informations nécessaires (à minima Repository URL)
 
-!!!info 
+!!!info
     Si votre dépôt est privé (pas très compréhensible mais pourquoi pas), il faudra aussi mettre les logins d'un compte ayant un accès en lecture au dépôt. Evitez donc de mettre un compte github personnel, mais créez plutôt un compte à l'association, afin d'assurer une meilleure passation.
 
-Ensuite, il faut activer les `GitOps updates` et choisir le méchanisme `Webhook`. 
+Ensuite, il faut activer les `GitOps updates` et choisir le méchanisme `Webhook`.
 Gardez le lien, il servira pour l'étape de fin.
 
 Enfin, il ne reste plus qu'à ajouter les variables d'environment et à mettre l'access control sur `Restricted` en authorisant la team du même nom que l'environment.
@@ -188,7 +188,7 @@ deploy:
     needs: [ build-and-push ]
     uses: Eirbware/.github/.github/workflows/deploy-stack.yml@master
     # portainer_stack_webhook must be defined
-    secrets: 
+    secrets:
         portainer_stack_webhook: ${{ secrets.portainer_stack_webhook }}
         wireguard_conf: ${{ secrets.wireguard_conf }}
 ```
@@ -198,8 +198,8 @@ La seule chose dont il y a besoin, c'est de 2 secrets:
 * `portainer_stack_webhook` (obligatoire): c'est le lien récupéré lors de l'étape précédente
 * `wireguard_conf` (obligatoire): configuration vpn pour pouvoir communiquer avec portainer, nous vous la donnerons
 
-!!!warning 
+!!!warning
     Ne pas oublier d'utiliser le champ `needs: [ <job-before-1>, <job-before-2>, ... ]`, sans quoi portainer tentera de déployer la nouvelle version du service avant que l'image ait fini d'être publiée
 
-!!!info 
+!!!info
     Pour les services dont les dépôts sont sur l'organisation github d'Eirbware, il n'y a pas besoin de configurer la variable `wireguard_conf`, car elle est déjà configurée pour toute l'organisation.

--- a/mkdocs/docs/respo_web/ci_manuel.md
+++ b/mkdocs/docs/respo_web/ci_manuel.md
@@ -1,0 +1,142 @@
+# CI/CD manuel
+
+Cette page explique comment créer sa propre pipeline de déploiement d'un site statique, mis en exemple avec un site construit dans un projet npm et déployé par une pipeline [Gitlab](https://gitlab.com/). L'objectif est de garder un protocole aussi simple que possible afin de pouvoir l'adapter à des technologies différentes facilement soi-même ou avec l'aide d'un⋅e membre d'Eirbware. Si vous utilisez github ou que vous déployez un site utilisant un conteneur, vérifiez d'abord si une option de [CI Eirbware](./ci_eirbware.md) convient déjà.
+
+!!!warning
+    Cette page considère que vous disposez déjà d'un accès FTP manuel vers votre emplacement dans le serveur Eirbware. Si ce n'est pas le cas, commencez par [cette page](./acces_site.md).
+
+## Le fichier de CI
+
+Ceci est un exemple de fichier de CI pour gitlab (`.gitlab-ci.yml`) à mettre à la racine du projet. Les valeurs à remplacer sont:
+
+- `MONASSO`, à remplacer par le nom de votre asso/club. Par exemple, pour `essaim.eirb.fr`, on mettra `essaim`.
+- `VERSION_NODE` à remplacer par la version de node à utiliser (faire `node --version`), par exemple `22`, suivi éventuellement d'une version de debian pour fixer le comportement de `apt`, par exemple `22-trixie`. Vous pouvez consulter les tags disponibles [ici](https://hub.docker.com/_/node/tags)
+- Éventuellement `dist` à la dernière ligne si le site construit ne se situe pas dans le répertoire `dist/`.
+
+!!!info
+    Si vous n'utilisez pas node, vous pouvez simplement utiliser une [image debian](https://hub.docker.com/_/debian), par exemple `bookworm`, ou une autre image de votre choix correspondant à la technologie que vous utilisez.
+
+```yml title=".gitlab-ci.yml"
+publish:
+    image: "node:VERSION_NODE"
+    stage: deploy
+    only:
+        - main
+    script: |
+        set -v
+        #
+        # === 1: Install lftp ===
+        #
+        apt update
+        apt install lftp
+        #
+        # === 2: Configure ssh ===
+        #
+        mkdir -p ${HOME}/.ssh
+        echo "$SSH_PRIV_KEY" | base64 --decode > ${HOME}/.ssh/id_MONASSO
+        echo "$SSH_CERT" | base64 --decode > ${HOME}/.ssh/id_MONASSO-cert.pub
+        echo "$SSH_CONFIG" | base64 --decode > ${HOME}/.ssh/config
+        echo "$SSH_KNOWN_HOSTS" | base64 --decode > ${HOME}/.ssh/known_hosts
+        chmod 400 ${HOME}/.ssh/*
+        #
+        # === 3: Build ===
+        #
+        npm install
+        npm run build
+        #
+        # === 4: Deploy ===
+        #
+        lftp -c "open -u www-MONASSO, sftp://MONASSO; mirror -eRv dist nginx/www"
+```
+
+!!!warning
+    Si vous utilisez une plateforme autre que Gitlab, ce fichier aura un nom différent et une structure différente. Seul le script restera similaire.
+
+## Explication du fichier CI
+
+`image: "node:VERSION_NODE"`: Cela spécifie quelle image utiliser pour le conteneur qui va éventuellement construire votre site, puis l'envoyer vers le serveur eirbware. Dans ce cas, on utilise une image node car cela permet d'avoir npm pré-installé dans une version contrôlée. On pourrait aussi utiliser une image debian et installer une autre technologie manuellement.
+
+`only: - main`: Cela signifie à Gitlab que cette pipeline ne doit être exécutée que lors d'un commit sur la branche `main`. Cela vous permet de créer une autre branche de travail qui ne sera pas déployée.
+
+`script`: Cette balise indique le début du script qui sera exécuté sur le conteneur. Le conteneur dispose d'une copie de tout le code dans votre dépôt à la version actuelle et le script est exécuté à la racine de cette copie.
+
+## Explication du script
+
+`set -v` permet de copier toutes les commandes exécutées dans la sortie console, afin de monitorer et débugger le déroulement de votre pipeline, qui ne fonctionnera pas du premier coup.
+
+La première vraie étape consiste à installer le logiciel `lftp`. lftp est un outil permettant de cloner un répertoire ftp sans interaction, ce qui sera fait à la fin du script. Cette commande fonctionne sur les images basées sur debian trixie. À priori, elle devrait fonctionner sur toute image debian pendant de nombreuses années, mais il se pourrait qu'il faille un jour changer d'outil ou changer de commande d'installation.
+
+L'étape 2 configure les fichiers SSH. Les fichiers sont stockés dans des variables qu'on définira dans la partie [Variables SSH](#variables-ssh) ci-dessous. Ils sont décodés en base64 car certains fichiers ont besoin de retours à la ligne, qui ne peuvent pas être stockés dans des variables CI gitlab.
+
+L'étape 3 consiste à construire le site web. Cette étape dépend complètement des technologies utilisées. Dans le cas d'un site vanilla, cette étape n'est pas nécessaire et peut être supprimée.
+
+L'étape 4 copie le site depuis le conteneur vers le serveur Eirbware. lftp est utilisé avec l'option `-c` pour lui passer sans interaction les commandes à exécuter. D'abord la commande de connexion, puis la commande `mirror`:
+
+- `-eRv`
+    - `e` pour supprimer les fichiers distants qui n'existent pas dans la nouvelle version.
+    - `R` pour copier les fichier du conteneur vers le serveur distant (au lieu de l'inverse).
+    - `v` pour augmenter la verbosité de l'opération, voir chaque fichier copié/supprimé à distance.
+- `dist`: Le nom du dossier local où le site construit se trouve. Par exemple, à partir de la racine de votre projet, `dist/index.html` correspond à la page racine du site.
+- `nginx/www`: Le nom du dossier distant dans le serveur eirbware. Cette option ne devrait à priori pas être modifiée.
+
+## Variables SSH
+
+### Générer les variables
+
+Pour cette étape, nous conseillons de créer un nouveau répertoire sur votre machine, dans lequel on va créer 4 fichiers.
+
+Pour fonctionner, votre pipeline aura besoin des 4 variables `SSH_PRIV_KEY`, `SSH_CERT`, `SSH_CONFIG`, et `SSH_KNOWN_HOSTS`. Ces 4 variables correspondent respectivement aux 4 fichiers qui seront créés sur le conteneur: `~/.ssh/id_MONASSO`, `~/.ssh/id_MONASSO-cert.pub`, `~/.ssh/config`, et `~/.ssh/known_hosts`.
+
+Vous disposez normalement déjà d'une clé privée et d'un certificat pour accéder au serveur (sinon, lire [cette page](./acces_site.md)). Par la suite, nous appellerons ces fichiers `id_MONASSO` et `id_MONASSO-cert.pub`. Copiez ces 2 fichiers dans le répertoire créé.
+
+La variable `SSH_CONFIG` sera créée à partir d'un fichier qu'on va appeler `config` dans notre répertoire, ayant cette forme:
+
+```title="config"
+Host MONASSO
+    port 30
+    Hostname eirb.fr
+    User www-MONASSO
+    IdentityFile    ~/.ssh/id_MONASSO
+    CertificateFile ~/.ssh/id_MONASSO-cert.pub
+```
+
+Enfin, la variable `SSH_KNOWN_HOSTS` sera créée à partir d'un fichier qu'on va appeler `known_hosts` dans notre répertoire. La manière la plus simple de créer ce fichier est d'effectuer une première connexion depuis son poste en enregistrant le serveur eirbware comme hôte connu si la question est posée, puis, après avoir fermé la connexion, effectuer cette commande qui va copier la signature du serveur dans un nouveau fichier: `grep eirb.fr ~/.ssh/known_hosts > known_hosts`. Le fichier créé devrait ressembler à cela:
+
+```
+[eirb.fr]:30 ssh-ed25519 <signature>
+```
+
+Si ces 4 étapes se sont déroulées normalement, votre repertoire devrait ressembler à cela:
+
+```
+.
+├── config
+├── id_MONASSO
+├── id_MONASSO-cert.pub
+└── known_hosts
+```
+
+Pour obtenir les valeurs des variables à fournir à Gitlab, exécutez la commande `base64 <fichier> -w 0` sur chacun de ces fichiers. Cette commande va coder les fichiers en [base64](https://fr.wikipedia.org/wiki/Base64) pour les contenir dans une chaîne sans retour à la ligne, et les fichiers seront décodés dans le script exécuté par le conteneur.
+
+Par exemple, on exécute `base64 config -w 0` pour obtenir la valeur de la variable `SSH_CONFIG` qu'on donnera à Gitlab.
+
+### Enregistrer les variables dans Gitlab
+
+!!!warning
+    Cette étape est écrite pour Gitlab. Si vous utilisez une plateforme différente, cette partie n'est pas applicable.
+
+!!!warning
+    Il arrive que l'interface de Gitlab change et que des choses soient renommées. Si c'est le cas, demandez de l'aide à un membre d'Eirbware pour vous aider à trouver où se trouvent les options et pour signaler qu'il faut mettre cette documentation à jour.
+
+Dans la page d'accueil de votre projet, allez dans "Settings"/"Paramètres", puis "CI/CD". Ensuite, dans "Variables", cliquez sur "Add variable"/"Ajouter une variable". Pour chacune des 4 variables qu'on va ajouter, il va falloir paramétrer 6 éléments:
+
+- Visibilité: Pour les variables `SSH_CONFIG` et `SSH_KNOWN_HOSTS`, on peut se permettre de laisser le paramètre par défaut. Pour les 2 autres variables, il faut sélectionner "Masked and hidden"/"Masqué et caché", car il s'agit de secrets et elle ne doivent pas être révélées.
+- "Protect variable"/"Protéger la variable": Dans l'idéal, activer pour les 4 variables. Cela empêche que la variable ne soit lue et fuitée par un commit sur une nouvelle branche par un contributeur malveillant (seules les personnes peuvent contribuer, mais c'est par sécurité). Cela nécessitera de s'assurer que la branche utilisée pour le déploiement est activée comme branche protégée. Si cela vous paraît compliqué, désactivez le paramètre.
+- "Expand variable reference": À désactiver
+- Description: Laisser vide
+- "Key"/"Clé": Le nom de la variable (par exemple `SSH_CONFIG`)
+- "Value"/"Valeur": La valeur donnée après le codage en base64 à l'étape précédente.
+
+## Conclusion
+
+Normalement, votre pipeline de déploiement devrait désormais se lancer lors du prochain commit sur la branche `main` avec le fichier `.gitlab-ci.yml`. Pour suivre le déroulement de l'exécution, après avoir poussé le commit, rendez-vous sur la page du projet. Vous aurez, en haut de l'interface, un résumé du dernier commit, et une icône en cours / succès / échec qui vous mènera au suivi de l'exécution.

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -28,7 +28,8 @@ nav:
     - respo_web/acces_vpn.md
     - respo_web/maj_site.md
     - respo_web/connexion_cas.md
-    - respo_web/ci.md
+    - respo_web/ci_eirbware.md
+    - respo_web/ci_manuel.md
     - respo_web/conseils.md
     - respo_web/eirbconnect_documentation.md
   - About: about.md


### PR DESCRIPTION
Add documentation to manually create a static website deployment CI/CD pipeline for gitlab.